### PR TITLE
Zaphod/player spectator option modal

### DIFF
--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -1,0 +1,82 @@
+import { Dialog, Flex, Heading } from "@radix-ui/themes";
+import { GiAxeInStump, GiRaiseZombie } from "react-icons/gi";
+import { useDefiniteGame } from "../../store/GameContext";
+import { PiKnifeBold } from "react-icons/pi";
+import { LiaVoteYeaSolid } from "react-icons/lia";
+import { PlayerList } from ".";
+import {
+  useDecideFate,
+  useVotesToExecute,
+} from "../../store/actions/gmPlayerActions";
+import { useDeadVote } from "../../store/actions/gmActions";
+import { FaSkull } from "react-icons/fa6";
+import { PlayerName } from "./PlayerName";
+import { SetCountModal } from "../../shared/SetCount";
+
+export function PlayerControls({
+  player,
+  children,
+}: {
+  player: string;
+  children: React.ReactNode;
+}) {
+  const { game } = useDefiniteGame();
+  const [, decideFateLoading, , handleDecideFate] = useDecideFate();
+  const [, deadVoteLoading, , setDeadVote] = useDeadVote();
+  // const [, playerStatusesLoading, , setPlayerStatus] = usePlayerStatuses();
+  const [, , , setVotesToExecute] = useVotesToExecute();
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>{children}</Dialog.Trigger>
+      <Dialog.Content className="m-2">
+        <Flex gap="2" direction="column" className="py-2 capitalize">
+          <Flex className="justify-center pb-2" align="center">
+            {game.deadPlayers[player] && <FaSkull />}
+            <Heading className="mx-3">
+              <PlayerName player={player} />
+            </Heading>
+          </Flex>
+        </Flex>
+
+        <Flex direction="column" gap="2">
+          {/* VOTE TO EXECUTE */}
+          <SetCountModal
+            title="Set Votes to Execute:"
+            onSet={(votes: number) => setVotesToExecute(player, votes)}
+            defaultValue={game.onTheBlock[player] ?? 0}
+          >
+            <PlayerList.MenuItem
+              id={`${player}-vote-execute`}
+              label="Set Votes to Execute"
+            >
+              <GiAxeInStump />
+            </PlayerList.MenuItem>
+          </SetCountModal>
+
+          {/* TOGGLE DEAD VOTE */}
+          <PlayerList.MenuItem
+            id={`${player}-toggle-dead-vote`}
+            label={
+              game.deadVotes[player] ? "Return Dead Vote" : "Use Dead Vote"
+            }
+            onClick={() => setDeadVote(player, !game.deadVotes[player])}
+            disabled={deadVoteLoading}
+          >
+            <LiaVoteYeaSolid />
+          </PlayerList.MenuItem>
+
+          {/* KILL OR REVIVE */}
+          <PlayerList.MenuItem
+            onClick={() => handleDecideFate(player, !game.deadPlayers[player])}
+            disabled={decideFateLoading}
+            id={`${player}-toggle-dead`}
+            label={game.deadPlayers[player] ? "Revive" : "Kill"}
+          >
+            {game.deadPlayers[player] ? <GiRaiseZombie /> : <PiKnifeBold />}
+          </PlayerList.MenuItem>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Dialog,
   Flex,
   Heading,
@@ -75,9 +76,11 @@ export function SetCount({
 export function PlayerControls({
   player,
   children,
+  onSet,
 }: {
   player: string;
   children: React.ReactNode;
+  onSet: (num: number) => void;
 }) {
   const { game } = useDefiniteGame();
   const [, decideFateLoading, , handleDecideFate] = useDecideFate();
@@ -111,30 +114,21 @@ export function PlayerControls({
           </PlayerList.MenuItem>
 
           {/* TOGGLE DEAD VOTE */}
-          <PlayerList.MenuItem
-            id={`${player}-toggle-dead-vote`}
-            label={
-              game.deadVotes[player] ? "Return Dead Vote" : "Use Dead Vote"
-            }
-            onClick={() => setDeadVote(player, !game.deadVotes[player])}
-            disabled={deadVoteLoading}
-          >
-            <LiaVoteYeaSolid />
-          </PlayerList.MenuItem>
-
-          {/* VOTE TO EXECUTE */}
-          {/* <SetCountModal
-            title="Set Votes to Execute:"
-            onSet={(votes: number) => setVotesToExecute(player, votes)}
-            defaultValue={game.onTheBlock[player] ?? 0}
+          <div
+            className={game.deadPlayers[player] ? "opacity-100" : "opacity-0"}
           >
             <PlayerList.MenuItem
-              id={`${player}-vote-execute`}
-              label="Set Votes to Execute"
+              id={`${player}-toggle-dead-vote`}
+              label={
+                game.deadVotes[player] ? "Return Dead Vote" : "Use Dead Vote"
+              }
+              onClick={() => setDeadVote(player, !game.deadVotes[player])}
+              disabled={deadVoteLoading || !game.deadPlayers[player]}
             >
-              <GiAxeInStump />
-            </PlayerList.MenuItem> 
-          </SetCountModal>*/}
+              <LiaVoteYeaSolid />
+            </PlayerList.MenuItem>
+          </div>
+          {/* VOTE TO EXECUTE */}
           <Flex direction="column" gap="3">
             <Text className="text-xl">Set Votes to Execute:</Text>
             <Text size="8">
@@ -142,6 +136,11 @@ export function PlayerControls({
                 <SetCount count={votes} setCount={setVotes} autoFocus />
               </Flex>
             </Text>
+            <Dialog.Close>
+              <Button size="3" onClick={() => onSet(votes)}>
+                Confirm
+              </Button>
+            </Dialog.Close>
           </Flex>
         </Flex>
       </Dialog.Content>

--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -23,7 +23,6 @@ export function PlayerControls({
   const { game } = useDefiniteGame();
   const [, decideFateLoading, , handleDecideFate] = useDecideFate();
   const [, deadVoteLoading, , setDeadVote] = useDeadVote();
-  // const [, playerStatusesLoading, , setPlayerStatus] = usePlayerStatuses();
   const [, , , setVotesToExecute] = useVotesToExecute();
 
   return (
@@ -66,7 +65,7 @@ export function PlayerControls({
             <LiaVoteYeaSolid />
           </PlayerList.MenuItem>
 
-          {/* KILL OR REVIVE */}
+          {/* KILL OR REVIVE PLAYER*/}
           <PlayerList.MenuItem
             onClick={() => handleDecideFate(player, !game.deadPlayers[player])}
             disabled={decideFateLoading}

--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  Dialog,
-  Flex,
-  Heading,
-  IconButton,
-  Text,
-  TextField,
-} from "@radix-ui/themes";
+import { Button, Dialog, Flex, Heading, Text } from "@radix-ui/themes";
 import { GiRaiseZombie } from "react-icons/gi";
 import { useDefiniteGame } from "../../store/GameContext";
 import { PiKnifeBold } from "react-icons/pi";
@@ -17,61 +9,8 @@ import { useDeadVote } from "../../store/actions/gmActions";
 import { FaSkull } from "react-icons/fa6";
 import { PlayerName } from "./PlayerName";
 import React from "react";
-import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
 import { DialogHeader } from "../../shared/DialogHeader";
-
-interface SetCountProps {
-  count: number;
-  setCount: React.Dispatch<React.SetStateAction<number>>;
-  min?: number;
-  max?: number;
-  autoFocus?: boolean;
-}
-export function SetCount({
-  count,
-  setCount,
-  min = 0,
-  max = 100,
-  autoFocus = false,
-}: SetCountProps) {
-  return (
-    <>
-      <IconButton
-        variant="soft"
-        radius="full"
-        size="3"
-        onClick={() => setCount((curr) => Math.max(curr - 1, min))}
-      >
-        <AiOutlineMinus />
-      </IconButton>
-      <TextField.Input
-        className="w-6"
-        size="3"
-        type="number"
-        value={count}
-        onChange={(e) =>
-          setCount(
-            Number.parseInt(
-              e.currentTarget.value ? e.currentTarget.value : "0",
-            ),
-          )
-        }
-        min={min}
-        max={max}
-        autoFocus={autoFocus}
-        onFocus={(e) => e.currentTarget.select()}
-      />
-      <IconButton
-        variant="soft"
-        radius="full"
-        size="3"
-        onClick={() => setCount((curr) => Math.min(curr + 1, max))}
-      >
-        <AiOutlinePlus />
-      </IconButton>
-    </>
-  );
-}
+import { SetCount } from "../../shared/SetCount";
 
 export function PlayerControls({
   player,
@@ -95,7 +34,9 @@ export function PlayerControls({
       <Dialog.Content className="m-2">
         <DialogHeader>
           <Flex className="flex-1 justify-center " align="center" gap="3">
-            {game.deadPlayers[player] && <FaSkull />}
+            <FaSkull
+              className={game.deadPlayers[player] ? "opacity-100" : "opacity-0"}
+            />
             <Heading>
               <PlayerName player={player} />
             </Heading>

--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -1,17 +1,75 @@
-import { Dialog, Flex, Heading } from "@radix-ui/themes";
-import { GiAxeInStump, GiRaiseZombie } from "react-icons/gi";
+import {
+  Dialog,
+  Flex,
+  Heading,
+  IconButton,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
+import { GiRaiseZombie } from "react-icons/gi";
 import { useDefiniteGame } from "../../store/GameContext";
 import { PiKnifeBold } from "react-icons/pi";
 import { LiaVoteYeaSolid } from "react-icons/lia";
 import { PlayerList } from ".";
-import {
-  useDecideFate,
-  useVotesToExecute,
-} from "../../store/actions/gmPlayerActions";
+import { useDecideFate } from "../../store/actions/gmPlayerActions";
 import { useDeadVote } from "../../store/actions/gmActions";
 import { FaSkull } from "react-icons/fa6";
 import { PlayerName } from "./PlayerName";
-import { SetCountModal } from "../../shared/SetCount";
+import React from "react";
+import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
+
+interface SetCountProps {
+  count: number;
+  setCount: React.Dispatch<React.SetStateAction<number>>;
+  min?: number;
+  max?: number;
+  autoFocus?: boolean;
+}
+export function SetCount({
+  count,
+  setCount,
+  min = 0,
+  max = 100,
+  autoFocus = false,
+}: SetCountProps) {
+  return (
+    <>
+      <IconButton
+        variant="soft"
+        radius="full"
+        size="3"
+        onClick={() => setCount((curr) => Math.max(curr - 1, min))}
+      >
+        <AiOutlineMinus />
+      </IconButton>
+      <TextField.Input
+        className="w-6"
+        size="3"
+        type="number"
+        value={count}
+        onChange={(e) =>
+          setCount(
+            Number.parseInt(
+              e.currentTarget.value ? e.currentTarget.value : "0",
+            ),
+          )
+        }
+        min={min}
+        max={max}
+        autoFocus={autoFocus}
+        onFocus={(e) => e.currentTarget.select()}
+      />
+      <IconButton
+        variant="soft"
+        radius="full"
+        size="3"
+        onClick={() => setCount((curr) => Math.min(curr + 1, max))}
+      >
+        <AiOutlinePlus />
+      </IconButton>
+    </>
+  );
+}
 
 export function PlayerControls({
   player,
@@ -23,10 +81,12 @@ export function PlayerControls({
   const { game } = useDefiniteGame();
   const [, decideFateLoading, , handleDecideFate] = useDecideFate();
   const [, deadVoteLoading, , setDeadVote] = useDeadVote();
-  const [, , , setVotesToExecute] = useVotesToExecute();
+  const [votes, setVotes] = React.useState<number>(
+    game.onTheBlock[player] ?? 0,
+  );
 
   return (
-    <Dialog.Root>
+    <Dialog.Root onOpenChange={() => setVotes(game.onTheBlock[player] ?? 0)}>
       <Dialog.Trigger>{children}</Dialog.Trigger>
       <Dialog.Content className="m-2">
         <Flex gap="2" direction="column" className="py-2 capitalize">
@@ -39,19 +99,15 @@ export function PlayerControls({
         </Flex>
 
         <Flex direction="column" gap="2">
-          {/* VOTE TO EXECUTE */}
-          <SetCountModal
-            title="Set Votes to Execute:"
-            onSet={(votes: number) => setVotesToExecute(player, votes)}
-            defaultValue={game.onTheBlock[player] ?? 0}
+          {/* KILL OR REVIVE PLAYER*/}
+          <PlayerList.MenuItem
+            onClick={() => handleDecideFate(player, !game.deadPlayers[player])}
+            disabled={decideFateLoading}
+            id={`${player}-toggle-dead`}
+            label={game.deadPlayers[player] ? "Revive" : "Kill"}
           >
-            <PlayerList.MenuItem
-              id={`${player}-vote-execute`}
-              label="Set Votes to Execute"
-            >
-              <GiAxeInStump />
-            </PlayerList.MenuItem>
-          </SetCountModal>
+            {game.deadPlayers[player] ? <GiRaiseZombie /> : <PiKnifeBold />}
+          </PlayerList.MenuItem>
 
           {/* TOGGLE DEAD VOTE */}
           <PlayerList.MenuItem
@@ -65,15 +121,27 @@ export function PlayerControls({
             <LiaVoteYeaSolid />
           </PlayerList.MenuItem>
 
-          {/* KILL OR REVIVE PLAYER*/}
-          <PlayerList.MenuItem
-            onClick={() => handleDecideFate(player, !game.deadPlayers[player])}
-            disabled={decideFateLoading}
-            id={`${player}-toggle-dead`}
-            label={game.deadPlayers[player] ? "Revive" : "Kill"}
+          {/* VOTE TO EXECUTE */}
+          {/* <SetCountModal
+            title="Set Votes to Execute:"
+            onSet={(votes: number) => setVotesToExecute(player, votes)}
+            defaultValue={game.onTheBlock[player] ?? 0}
           >
-            {game.deadPlayers[player] ? <GiRaiseZombie /> : <PiKnifeBold />}
-          </PlayerList.MenuItem>
+            <PlayerList.MenuItem
+              id={`${player}-vote-execute`}
+              label="Set Votes to Execute"
+            >
+              <GiAxeInStump />
+            </PlayerList.MenuItem> 
+          </SetCountModal>*/}
+          <Flex direction="column" gap="3">
+            <Text className="text-xl">Set Votes to Execute:</Text>
+            <Text size="8">
+              <Flex justify="center" align="center" gap="7">
+                <SetCount count={votes} setCount={setVotes} autoFocus />
+              </Flex>
+            </Text>
+          </Flex>
         </Flex>
       </Dialog.Content>
     </Dialog.Root>

--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -7,10 +7,10 @@ import { PlayerList } from ".";
 import { useDecideFate } from "../../store/actions/gmPlayerActions";
 import { useDeadVote } from "../../store/actions/gmActions";
 import { FaSkull } from "react-icons/fa6";
-import { PlayerName } from "./PlayerName";
 import React from "react";
 import { DialogHeader } from "../../shared/DialogHeader";
 import { SetCount } from "../../shared/SetCount";
+import classNames from "classnames";
 
 export function PlayerControls({
   player,
@@ -38,7 +38,14 @@ export function PlayerControls({
               className={game.deadPlayers[player] ? "opacity-100" : "opacity-0"}
             />
             <Heading>
-              <PlayerName player={player} />
+              <Text
+                className={classNames(
+                  "flex-1 capitalize",
+                  game.deadPlayers[player] && "line-through",
+                )}
+              >
+                {player}
+              </Text>
             </Heading>
           </Flex>
         </DialogHeader>
@@ -70,15 +77,15 @@ export function PlayerControls({
             </PlayerList.MenuItem>
           </div>
           {/* VOTE TO EXECUTE */}
-          <Flex direction="column" gap="3">
-            <Text className="text-xl">Set Votes to Execute:</Text>
+          <Flex direction="column" gap="4" className="mt-2">
+            <Text className="text-center text-xl">Votes to Execute</Text>
             <Text size="8">
               <Flex justify="center" align="center" gap="7">
                 <SetCount count={votes} setCount={setVotes} autoFocus />
               </Flex>
             </Text>
             <Dialog.Close>
-              <Button size="3" onClick={() => onSet(votes)}>
+              <Button size="3" className="mt-1" onClick={() => onSet(votes)}>
                 Confirm
               </Button>
             </Dialog.Close>

--- a/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/PlayerControls.tsx
@@ -17,6 +17,7 @@ import { FaSkull } from "react-icons/fa6";
 import { PlayerName } from "./PlayerName";
 import React from "react";
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
+import { DialogHeader } from "../../shared/DialogHeader";
 
 interface SetCountProps {
   count: number;
@@ -89,14 +90,14 @@ export function PlayerControls({
     <Dialog.Root onOpenChange={() => setVotes(game.onTheBlock[player] ?? 0)}>
       <Dialog.Trigger>{children}</Dialog.Trigger>
       <Dialog.Content className="m-2">
-        <Flex gap="2" direction="column" className="py-2 capitalize">
-          <Flex className="justify-center pb-2" align="center">
+        <DialogHeader>
+          <Flex className="flex-1 justify-center " align="center" gap="3">
             {game.deadPlayers[player] && <FaSkull />}
-            <Heading className="mx-3">
+            <Heading>
               <PlayerName player={player} />
             </Heading>
           </Flex>
-        </Flex>
+        </DialogHeader>
 
         <Flex direction="column" gap="2">
           {/* KILL OR REVIVE PLAYER*/}

--- a/client/src/GamemasterInGame/PlayerListComponents/index.tsx
+++ b/client/src/GamemasterInGame/PlayerListComponents/index.tsx
@@ -5,6 +5,7 @@ import { PlayerRoleIcon } from "./PlayerRole";
 import { PlayerNoteInput } from "./PlayerNoteInput";
 import { PlayerMenuItem } from "./PlayerMenuItem";
 import { PlayerMessageFlow } from "./PlayerMessage";
+import { PlayerControls } from "./PlayerControls";
 
 export const PlayerList = {
   RoleIcon: PlayerRoleIcon,
@@ -14,4 +15,6 @@ export const PlayerList = {
   MenuItem: PlayerMenuItem,
   NoteInputModal: PlayerNoteInput,
   PlayerMessage: PlayerMessageFlow,
+  // TODO: Route PlayerControls through here. SpectatorControls to route elsewhere in another PR.
+  PlayerControls: PlayerControls,
 };

--- a/client/src/PlayerLanding/PlayerInGame.tsx
+++ b/client/src/PlayerLanding/PlayerInGame.tsx
@@ -13,7 +13,7 @@ import { LiaVoteYeaSolid } from "react-icons/lia";
 import classNames from "classnames";
 import { useMe } from "../store/usePlayer";
 import { BsFillMoonStarsFill, BsPeopleFill } from "react-icons/bs";
-import { GiAxeInStump, GiScrollQuill } from "react-icons/gi";
+import { GiScrollQuill } from "react-icons/gi";
 import React, { useState } from "react";
 import { getCharacter } from "@hidden-identity/shared";
 import {
@@ -31,9 +31,9 @@ import {
 } from "../shared/PlayerListOrder";
 import { TeamDistributionBar } from "../shared/TeamDistributionBar";
 import { useFirstSeat } from "../store/url";
-import { SetCountModal } from "../shared/SetCount";
-import { useVotesToExecute } from "../store/actions/gmPlayerActions";
 import { ExecutionInfo } from "../shared/ExecutionInfo";
+import { PlayerList } from "../GamemasterInGame/PlayerListComponents";
+import { RxHamburgerMenu } from "react-icons/rx";
 
 export function PlayerInGame() {
   const { game, script } = useDefiniteGame();
@@ -47,7 +47,6 @@ export function PlayerInGame() {
   const [selectedFilter, setSelectedFilter] = useState<PlayerFilter>("all");
   const filteredPlayers = allFilters[selectedFilter];
   const [isFirstNightSort, setIsFirstNightSort] = React.useState(false);
-  const [, , , setVotesToExecute] = useVotesToExecute();
 
   const nightOrder = React.useMemo(() => {
     const charactersFromScript =
@@ -212,15 +211,11 @@ export function PlayerInGame() {
                     Votes: {game.onTheBlock[player]}
                   </Text>
                 )}
-                <SetCountModal
-                  title="Set votes to execute:"
-                  onSet={(votes: number) => setVotesToExecute(player, votes)}
-                  defaultValue={game.onTheBlock[player] ?? 0}
-                >
-                  <IconButton variant="soft" radius="large">
-                    <GiAxeInStump />
+                <PlayerList.PlayerControls player={player}>
+                  <IconButton id={`${player}-menu-btn`} variant="ghost">
+                    <RxHamburgerMenu />
                   </IconButton>
-                </SetCountModal>
+                </PlayerList.PlayerControls>
               </Flex>
             ))}
           </Flex>

--- a/client/src/PlayerLanding/PlayerInGame.tsx
+++ b/client/src/PlayerLanding/PlayerInGame.tsx
@@ -34,6 +34,7 @@ import { useFirstSeat } from "../store/url";
 import { ExecutionInfo } from "../shared/ExecutionInfo";
 import { PlayerList } from "../GamemasterInGame/PlayerListComponents";
 import { RxHamburgerMenu } from "react-icons/rx";
+import { useVotesToExecute } from "../store/actions/gmPlayerActions";
 
 export function PlayerInGame() {
   const { game, script } = useDefiniteGame();
@@ -47,6 +48,7 @@ export function PlayerInGame() {
   const [selectedFilter, setSelectedFilter] = useState<PlayerFilter>("all");
   const filteredPlayers = allFilters[selectedFilter];
   const [isFirstNightSort, setIsFirstNightSort] = React.useState(false);
+  const [, , , setVotesToExecute] = useVotesToExecute();
 
   const nightOrder = React.useMemo(() => {
     const charactersFromScript =
@@ -211,7 +213,10 @@ export function PlayerInGame() {
                     Votes: {game.onTheBlock[player]}
                   </Text>
                 )}
-                <PlayerList.PlayerControls player={player}>
+                <PlayerList.PlayerControls
+                  player={player}
+                  onSet={(votes: number) => setVotesToExecute(player, votes)}
+                >
                   <IconButton id={`${player}-menu-btn`} variant="ghost">
                     <RxHamburgerMenu />
                   </IconButton>

--- a/client/src/shared/DialogHeader.tsx
+++ b/client/src/shared/DialogHeader.tsx
@@ -4,7 +4,9 @@ import { Dialog, Flex, IconButton } from "@radix-ui/themes";
 export function DialogHeader(props: { children: React.ReactNode }) {
   return (
     <Flex className="w-full" justify={props.children ? "between" : "end"}>
-      {props.children && <Dialog.Title>{props.children}</Dialog.Title>}
+      {props.children && (
+        <Dialog.Title className="flex-1">{props.children}</Dialog.Title>
+      )}
       <Dialog.Close>
         <IconButton variant="ghost" radius="full" size="1" className="w-fit">
           <Cross1Icon />


### PR DESCRIPTION
Major Player Menu adjustment. Replaced Votes to Execute button with Player Menu that allows Players to mark players as dead/revived, used their dead vote, and incorporated the votes to execute modal.
![image](https://github.com/Hidden-Identity-Games/blood-on-the-clocktower/assets/10368192/fe7c916b-a2b6-4851-8b99-9220ccb4fa34)
![image](https://github.com/Hidden-Identity-Games/blood-on-the-clocktower/assets/10368192/bfbbc148-845f-4d8d-bf00-86bf4d228d77)
![image](https://github.com/Hidden-Identity-Games/blood-on-the-clocktower/assets/10368192/9fad9f21-8e96-4fb1-a009-0277b92bd38f)

*Note that nothing regarding the spectator mode has been modified despite the branch name.