### PR TITLE
make night action applying statuses easier

### DIFF
--- a/client/src/GMRoute/GMShared/PlayerListComponents/PlayerMessage/ReminderCreator/index.tsx
+++ b/client/src/GMRoute/GMShared/PlayerListComponents/PlayerMessage/ReminderCreator/index.tsx
@@ -1,0 +1,82 @@
+import { getAllReminders } from "@hidden-identity/shared";
+import { Button, Dialog } from "@radix-ui/themes";
+import { useMemo } from "react";
+
+import { DialogHeader } from "../../../../../shared/DialogHeader";
+import {
+  PlayerNameWithRoleIcon,
+  RoleIcon,
+} from "../../../../../shared/RoleIcon";
+import { usePlayerReminder } from "../../../../../store/actions/gmPlayerActions";
+import { useDefiniteGame } from "../../../../../store/GameContext";
+
+export interface ReminderCreatorProps {
+  reminder: string;
+  fromPlayer: string;
+}
+export function ReminderCreator({
+  reminder,
+  fromPlayer,
+}: ReminderCreatorProps) {
+  const { game } = useDefiniteGame();
+  const [, , , setHaseReminder] = usePlayerReminder();
+  const relevantReminders = useMemo(
+    () => game.reminders.filter(({ name }) => name === reminder),
+    [game.reminders, reminder],
+  );
+  const playerHasReminder = (player: string) =>
+    relevantReminders.find((reminder) => reminder.toPlayer === player);
+
+  // don't change the ordering when statuses change
+  const frozenPlayerList = useMemo(() => {
+    return [...game.playerList].sort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Dialog.Root>
+        <Dialog.Trigger>
+          <Button>Apply {reminder}</Button>
+        </Dialog.Trigger>
+
+        <Dialog.Content>
+          <div className="flex flex-col gap-1">
+            <DialogHeader>Applying {reminder}</DialogHeader>
+            <Dialog.Close key="cancel">
+              <Button
+                className="capitalize"
+                size="3"
+                variant="soft"
+                color="lime"
+              >
+                {"Done"}
+              </Button>
+            </Dialog.Close>
+            {frozenPlayerList.map((toPlayer) => (
+              <Button
+                key={toPlayer}
+                className="capitalize"
+                size="3"
+                color="violet"
+                variant={playerHasReminder(toPlayer) ? "soft" : "outline"}
+                onClick={() => {
+                  void setHaseReminder({
+                    name: reminder,
+                    toPlayer,
+                    fromPlayer,
+                  });
+                }}
+              >
+                <PlayerNameWithRoleIcon player={toPlayer} />
+                {playerHasReminder(toPlayer) && (
+                  <RoleIcon role={getAllReminders()[reminder].role} />
+                )}
+              </Button>
+            ))}
+          </div>
+        </Dialog.Content>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/client/src/GMRoute/GMShared/PlayerListComponents/PlayerMessage/messageShared/SubmitMessage.tsx
+++ b/client/src/GMRoute/GMShared/PlayerListComponents/PlayerMessage/messageShared/SubmitMessage.tsx
@@ -27,6 +27,7 @@ export function SubmitMessage({ message, player, action }: SubmitMessageProps) {
       <ErrorCallout error={createMessageError} />
       {!messageId && (
         <Button
+          className="w-full"
           disabled={createMessageisLoading && message.length === 0}
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={async () => {

--- a/client/src/shared/Sheet/SheetTypes/ActionSheet/PlayerActionSheet.tsx
+++ b/client/src/shared/Sheet/SheetTypes/ActionSheet/PlayerActionSheet.tsx
@@ -6,6 +6,7 @@ import {
 
 import { PlayerMessageFlow } from "../../../../GMRoute/GMShared/PlayerListComponents/PlayerMessage";
 import { SubmitMessage } from "../../../../GMRoute/GMShared/PlayerListComponents/PlayerMessage/messageShared/SubmitMessage";
+import { ReminderCreator } from "../../../../GMRoute/GMShared/PlayerListComponents/PlayerMessage/ReminderCreator";
 import { useDefiniteGame } from "../../../../store/GameContext";
 import { PlayerNameWithRoleIcon, RoleName } from "../../../RoleIcon";
 import { SheetBody, SheetContent, SheetHeader } from "../../SheetBody";
@@ -30,14 +31,26 @@ function Body({ action }: PlayerSheetProps) {
   const ability = getAbility(role, game.time);
 
   return (
-    <div className="flex">
+    <div className="flex flex-col gap-2">
       {ability?.playerMessage ? (
         <PlayerMessageFlow action={action} message={ability.playerMessage} />
       ) : (
-        <div>
-          {getCharacter(role).ability}{" "}
-          <SubmitMessage action={action} message={[]} player={action.player} />
-        </div>
+        <>
+          <div>{getCharacter(role).ability}</div>
+          {ability?.setReminders?.map((reminderName) => (
+            <ReminderCreator
+              reminder={reminderName}
+              fromPlayer={action.player}
+            />
+          ))}
+          <div className="w-full">
+            <SubmitMessage
+              action={action}
+              message={[]}
+              player={action.player}
+            />
+          </div>
+        </>
       )}
     </div>
   );

--- a/client/test/characterData.spec.ts
+++ b/client/test/characterData.spec.ts
@@ -1,0 +1,34 @@
+import { allCharactersList } from "@hidden-identity/shared";
+import { describe, expect, test } from "vitest";
+
+describe("characterData", () => {
+  describe("reminders", () => {
+    test("no two characters have the same reminder name", () => {
+      const seenSet = new Set<string>();
+      const duplicates = allCharactersList()
+        .flatMap(({ reminders }) => reminders)
+        .filter((reminder) => {
+          if (seenSet.has(reminder.name)) {
+            return true;
+          } else {
+            seenSet.add(reminder.name);
+            return false;
+          }
+        });
+      expect(duplicates).toHaveLength(0);
+    });
+    describe.each(allCharactersList())("character: $name", (character) => {
+      test("has only defined reminders", () => {
+        const reminderNames = character.reminders.map(({ name }) => name);
+        const allReminderReferences = [
+          ...(character.firstNight?.setReminders || []),
+          ...(character.otherNight?.setReminders || []),
+        ];
+
+        expect(
+          allReminderReferences.filter((name) => !reminderNames.includes(name)),
+        ).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/shared/src/gameData/characterData.ts
+++ b/shared/src/gameData/characterData.ts
@@ -9,7 +9,10 @@ export type ReminderType =
   | "protected"
   | "triggerOnDeath"
   | "reveal-role"
-  | "counter";
+  | "counter"
+  | "hasAbility"
+  | "abilitySpent";
+
 export type TargetType = "self" | "other";
 type CharacterDefinition = Omit<Character, "id"> & {
   id: string;
@@ -17,11 +20,13 @@ type CharacterDefinition = Omit<Character, "id"> & {
   reminders: Reminder[];
 };
 
-const ABILITY_SPENT = {
-  name: "ability spent",
-  type: "drunk",
-  target: "self",
-} as const;
+function abilitySpent(character: string) {
+  return {
+    name: `${character} ability spent`,
+    type: "abilitySpent",
+    target: "self",
+  } as const;
+}
 
 export const CHARACTERS: CharacterDefinition[] = [
   {
@@ -56,7 +61,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Assassin",
     edition: "bmr",
     team: "Minion",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("assassin")],
     setup: false,
     delusional: false,
     ability:
@@ -64,7 +69,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     imageSrc: "assassin.png",
     firstNight: null,
     otherNight: {
-      setReminders: [ABILITY_SPENT.name],
+      setReminders: [abilitySpent("assassin").name],
       reminder:
         "If the Assassin has not yet used their ability: The Assassin either shows the 'no' head signal, or points to a player. That player dies.",
       order: 36,
@@ -153,7 +158,6 @@ export const CHARACTERS: CharacterDefinition[] = [
         name: "gone mad",
         type: "mad",
         duration: 1,
-        causedByDeath: true,
       },
     ],
     setup: false,
@@ -454,7 +458,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Fool",
     edition: "bmr",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("fool")],
     setup: false,
     delusional: false,
     ability: "The first time you die, you don't.",
@@ -990,19 +994,19 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Poisoner",
     edition: "tb",
     team: "Minion",
-    reminders: [{ name: "poisoned", type: "poison" }],
+    reminders: [{ name: "poisoner", type: "poison" }],
     setup: false,
     delusional: false,
     ability:
       "Each night, choose a player: they are poisoned tonight and tomorrow day.",
     imageSrc: "poisoner.png",
     firstNight: {
-      setReminders: ["poisoned"],
+      setReminders: ["poisoner"],
       reminder: "The Poisoner points to a player. That player is poisoned.",
       order: 17,
     },
     otherNight: {
-      setReminders: ["poisoned"],
+      setReminders: ["poisoner"],
       reminder:
         "The previously poisoned player is no longer poisoned. The Poisoner points to a player. That player is poisoned.",
       order: 7,
@@ -1013,7 +1017,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Professor",
     edition: "bmr",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("professor")],
     setup: false,
     delusional: false,
     ability:
@@ -1024,7 +1028,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       reminder:
         "If the Professor has not used their ability: The Professor either shakes their head no, or points to a player. If that player is a Townsfolk, they are now alive.",
       order: 43,
-      setReminders: [ABILITY_SPENT.name],
+      setReminders: [abilitySpent("professor").name],
       playerMessage: {
         type: "revived",
       },
@@ -1197,18 +1201,20 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Seamstress",
     edition: "snv",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("seamstress")],
     setup: false,
     delusional: false,
     ability:
       "Once per game, at night, choose 2 players (not yourself): you learn if they are the same alignment.",
     imageSrc: "seamstress.png",
     firstNight: {
+      setReminders: [abilitySpent("seamstress").name],
       reminder:
         "The Seamstress either shows a 'no' head signal, or points to two other players. If the Seamstress chose players , nod 'yes' or shake 'no' for whether they are of same alignment.",
       order: 43,
     },
     otherNight: {
+      setReminders: [abilitySpent("seamstress").name],
       reminder:
         "If the Seamstress has not yet used their ability: the Seamstress either shows a 'no' head signal, or points to two other players. If the Seamstress chose players , nod 'yes' or shake 'no' for whether they are of same alignment.",
       order: 60,
@@ -1240,7 +1246,14 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Slayer",
     edition: "tb",
     team: "Townsfolk",
-    reminders: [{ ...ABILITY_SPENT, dayTrigger: true }],
+    reminders: [
+      {
+        name: "slayed",
+        type: "abilitySpent",
+        target: "self",
+        dayTrigger: true,
+      },
+    ],
     setup: false,
     delusional: false,
     ability:
@@ -1422,8 +1435,8 @@ export const CHARACTERS: CharacterDefinition[] = [
     edition: "snv",
     team: "Demon",
     reminders: [
-      { name: "poisoned", type: "poison" },
-      { name: "has ability", type: "info" },
+      { name: "poisoned neighbor", type: "poison" },
+      { name: "minion keeps ability", type: "hasAbility" },
     ],
     setup: true,
     delusional: false,
@@ -1435,6 +1448,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       reminder:
         "The Vigormortis points to a player. That player dies. If a Minion, they keep their ability and one of their Townsfolk neighbours is poisoned.",
       order: 32,
+      setReminders: ["minion keeps ability", "poisoned neighbor"],
     },
   },
   {
@@ -1676,7 +1690,12 @@ export const CHARACTERS: CharacterDefinition[] = [
     edition: "",
     team: "Townsfolk",
     reminders: [
-      { name: "poisoned", type: "poison", causedByDeath: true, target: "self" },
+      {
+        name: "evil died",
+        type: "poison",
+        causedByDeath: true,
+        target: "self",
+      },
       { name: "died today", type: "info", causedByDeath: true },
     ],
     setup: false,
@@ -1745,14 +1764,14 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Engineer",
     edition: "",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("engineer")],
     setup: false,
     delusional: false,
     ability:
       "Once per game, at night, choose which Minions or which Demon is in play.",
     imageSrc: "engineer.png",
     firstNight: {
-      setReminders: ["ability spent"],
+      setReminders: [abilitySpent("engineer").name],
       reminder:
         "The Engineer shows a 'no' head signal, or points to a Demon or points to the relevant number of Minions. If the Engineer chose characters, replace the Demon or Minions with the choices, then wake the relevant players and show them the You are card and the relevant character tokens.",
       order: 13,
@@ -1762,7 +1781,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       },
     },
     otherNight: {
-      setReminders: ["ability spent"],
+      setReminders: [abilitySpent("engineer").name],
       reminder:
         "The Engineer shows a 'no' head signal, or points to a Demon or points to the relevant number of Minions. If the Engineer chose characters, replace the Demon or Minions with the choices, then wake the relevant players and show them the 'You are' card and the relevant character tokens.",
       order: 5,
@@ -1798,7 +1817,14 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Fisherman",
     edition: "",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [
+      {
+        name: "fished",
+        type: "abilitySpent",
+        dayTrigger: true,
+        target: "self",
+      },
+    ],
     setup: false,
     delusional: false,
     ability:
@@ -1834,14 +1860,14 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Huntsman",
     edition: "",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("huntsman")],
     setup: true,
     delusional: false,
     ability:
       "Once per game, at night, choose a living player: the Damsel, if chosen, becomes a not-in-play Townsfolk. [+the Damsel]",
     imageSrc: "huntsman.png",
     firstNight: {
-      setReminders: ["ability spent"],
+      setReminders: [abilitySpent("huntsman").name],
       reminder:
         "The Huntsman shakes their head 'no' or points to a player. If they point to the Damsel, wake that player, show the 'You are' card and a not-in-play character token.",
       order: 30,
@@ -1855,7 +1881,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       },
     },
     otherNight: {
-      setReminders: ["ability spent"],
+      setReminders: [abilitySpent("huntsman").name],
       reminder:
         "The Huntsman shakes their head 'no' or points to a player. If they point to the Damsel, wake that player, show the 'You are' card and a not-in-play character token.",
       order: 45,
@@ -1942,20 +1968,20 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Nightwatchman",
     edition: "",
     team: "Townsfolk",
-    reminders: [ABILITY_SPENT],
+    reminders: [abilitySpent("nightwatchman")],
     setup: false,
     delusional: false,
     ability:
       "Once per game, at night, choose a player: they learn who you are.",
     imageSrc: "nightwatchman.png",
     firstNight: {
-      setReminders: ["ability spent"],
+      setReminders: [abilitySpent("nightwatchman").name],
       reminder:
         "The Nightwatchman may point to a player. Wake that player, show the 'This character selected you' card and the Nightwatchman token, then point to the Nightwatchman player.",
       order: 47,
     },
     otherNight: {
-      setReminders: ["ability spent"],
+      setReminders: [abilitySpent("nightwatchman").name],
       reminder:
         "The Nightwatchman may point to a player. Wake that player, show the 'This character selected you' card and the Nightwatchman token, then point to the Nightwatchman player.",
       order: 65,
@@ -2001,7 +2027,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     team: "Townsfolk",
     reminders: [
       { name: "mad", type: "mad" },
-      { name: "has ability", type: "info", causedByDeath: true },
+      { name: "pixie ability", type: "hasAbility", causedByDeath: true },
     ],
     setup: false,
     delusional: false,
@@ -2009,7 +2035,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       "You start knowing 1 in-play Townsfolk. If you were mad that you were this character, you gain their ability when they die.",
     imageSrc: "pixie.png",
     firstNight: {
-      setReminders: ["mad", "has ability"],
+      setReminders: ["mad", "pixie ability"],
       reminder: "Show the Pixie 1 in-play Townsfolk character token.",
       order: 29,
       playerMessage: {
@@ -2104,14 +2130,21 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Damsel",
     edition: "",
     team: "Outsider",
-    reminders: [ABILITY_SPENT],
+    reminders: [
+      {
+        name: "guessed damsel",
+        type: "info",
+        dayTrigger: true,
+        target: "other",
+      },
+    ],
     setup: false,
     delusional: false,
     ability:
       "All Minions know you are in play. If a Minion publicly guesses you (once), your team loses.",
     imageSrc: "damsel.png",
     firstNight: {
-      setReminders: ["ability spent"],
+      setReminders: ["guessed damsel"],
       reminder:
         "Wake all the Minions, show them the 'This character selected you' card and the Damsel token.",
       order: 31,
@@ -2120,7 +2153,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       },
     },
     otherNight: {
-      setReminders: ["ability spent"],
+      setReminders: ["guessed damsel"],
       reminder:
         "If selected by the Huntsman, wake the Damsel, show 'You are' card and a not-in-play Townsfolk token.",
       order: 46,
@@ -2190,7 +2223,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     team: "Outsider",
     reminders: [
       { name: "drunk", type: "drunk", persistOnDeath: true },
-      ABILITY_SPENT,
+      abilitySpent("puzzlemaster"),
     ],
     setup: false,
     delusional: false,
@@ -2371,7 +2404,7 @@ export const CHARACTERS: CharacterDefinition[] = [
         dayReminder: true,
         target: "other",
       },
-      ABILITY_SPENT,
+      abilitySpent("secret word"),
     ],
     setup: false,
     delusional: false,
@@ -2379,12 +2412,12 @@ export const CHARACTERS: CharacterDefinition[] = [
       "You start knowing a secret word. The 1st good player to say this word becomes evil that night.",
     imageSrc: "mezepheles.png",
     firstNight: {
-      setReminders: ["turns evil", "ability spent"],
+      setReminders: ["turns evil", abilitySpent("secret word").name],
       reminder: "Show the Mezepheles their secret word.",
       order: 27,
     },
     otherNight: {
-      setReminders: ["turns evil", "ability spent"],
+      setReminders: ["turns evil", abilitySpent("secret word").name],
       reminder:
         "Wake the 1st good player that said the Mezepheles' secret word and show them the 'You are' card and the thumbs down evil signal.",
       order: 18,
@@ -2417,12 +2450,12 @@ export const CHARACTERS: CharacterDefinition[] = [
     team: "Demon",
     reminders: [
       {
-        name: "poisoned",
+        name: "leeched",
         type: "poison",
       },
       {
         name: "lleech dies",
-        type: "info",
+        type: "triggerOnDeath",
         causedByDeath: true,
       },
       {
@@ -2436,7 +2469,7 @@ export const CHARACTERS: CharacterDefinition[] = [
       "Each night*, choose a player: they die. You start by choosing an alive player: they are poisoned - you die if & only if they die.",
     imageSrc: "lleech.png",
     firstNight: {
-      setReminders: ["poisoned"],
+      setReminders: ["leeched"],
       reminder:
         "The Lleech points to a player. Place the Poisoned reminder token.",
       order: 16,
@@ -2649,7 +2682,7 @@ export const CHARACTERS: CharacterDefinition[] = [
     name: "Judge",
     edition: "bmr",
     team: "Traveler",
-    reminders: [ABILITY_SPENT],
+    reminders: [{ ...abilitySpent("judge"), dayTrigger: true }],
     setup: false,
     delusional: false,
     ability:
@@ -2769,10 +2802,10 @@ export const CHARACTERS: CharacterDefinition[] = [
     edition: "snv",
     team: "Traveler",
     reminders: [
-      ABILITY_SPENT,
+      abilitySpent("bone collector"),
       {
-        name: "has ability",
-        type: "info",
+        name: "has ability while dead",
+        type: "hasAbility",
         duration: 1,
         target: "other",
       },
@@ -2783,7 +2816,10 @@ export const CHARACTERS: CharacterDefinition[] = [
       "Once per game, at night, choose a dead player: they regain their ability until dusk.",
     firstNight: null,
     otherNight: {
-      setReminders: ["has ability", "ability spent"],
+      setReminders: [
+        "has ability while dead",
+        abilitySpent("bone collector").name,
+      ],
       reminder:
         "The Bone Collector either shakes their head no or points at any dead player. If they pointed at any dead player, put the Bone Collector's 'Has Ability' reminder by the chosen player's character token. (They may need to be woken tonight to use it.)",
       order: 1,

--- a/shared/src/gameData/gameData.ts
+++ b/shared/src/gameData/gameData.ts
@@ -2,6 +2,7 @@ import {
   type Alignment,
   type Character,
   type CharacterType,
+  type Reminder,
   type Role,
 } from "../shapes/Role.ts";
 import { type Script } from "../shapes/Script.ts";
@@ -47,6 +48,16 @@ export function getDefaultAlignment(role: Role) {
 
 export function getCharacter(role: Role): Character {
   return characters[role ?? "unassigned"];
+}
+
+export function getAllReminders(): Record<string, Reminder & { role: Role }> {
+  return Object.fromEntries(
+    allCharactersList()
+      .flatMap(({ reminders, id }) =>
+        reminders.map((r) => ({ ...r, role: id as Role })),
+      )
+      .map((reminder) => [reminder.name, reminder]),
+  );
 }
 
 const scripts: Record<ScriptName, Script> = Object.fromEntries(

--- a/shared/src/shapes/PlayerReminder.ts
+++ b/shared/src/shapes/PlayerReminder.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export const playerReminderShape = z.object({
   name: z.string(),
-  role: z.string(),
   toPlayer: z.string(),
   fromPlayer: z.string().optional(),
 });

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -24,6 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "rootDir": "./src"
   },
-  "include": ["src"],
+  "include": ["src", "../client/test/characterData.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
<img width="839" alt="image" src="https://github.com/Hidden-Identity-Games/blood-on-the-clocktower/assets/18182784/9cbf1638-2958-47f1-8e01-7541b91d38a6">

Adds a button to all night actions for each status we expect to apply. Right now it applies the status right away, but this is just a verys imple V1 of the feature.  We likely want to queue it up, and apply statuses all at once in a "commit" that also generates a message and/or log entry 